### PR TITLE
Fix README link to point to correct autorebase repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ We recommend the following strategy when doing this:
 
 ## Attribution
 
-AutoRebase is heavily inspired by [tibdex/autosquash](https://github.com/tibdex/autosquash) and [tibdex/autorebase](https://github.com/tibdex/autosquash).
+AutoRebase is heavily inspired by [tibdex/autosquash](https://github.com/tibdex/autosquash) and [tibdex/autorebase](https://github.com/tibdex/autorebase).


### PR DESCRIPTION
I noticed that both links pointed to autosquash, so I fixed the incorrect link